### PR TITLE
Update nlateral_demo.cc

### DIFF
--- a/nlateral_demo.cc
+++ b/nlateral_demo.cc
@@ -79,8 +79,8 @@ struct Servo {
   static Servo Parse(const std::string& message) {
     auto fields = Split(message);
     Servo result;
-    result.id = std::stol(fields.at(0));
-    fields.erase(fields.begin());
+    result.id = std::atol(fields[0].c_str());
+    fields[0].erase(fields[0].begin());
     for (const auto& field : fields) {
       if (field.at(0) == 'b') {
         result.bus = std::stol(field.substr(1));

--- a/nlateral_demo.cc
+++ b/nlateral_demo.cc
@@ -85,30 +85,32 @@ struct Servo {
     }
     result.id = std::stol(fields[0].substr(0, id_end));
     fields[0].erase(0, id_end);
-    for (const auto& field : fields) {
-      if (field.at(0) == 'b') {
-        result.bus = std::stol(field.substr(1));
-      } else if (field.at(0) == 'p') {
-        result.position_scale = std::stod(field.substr(1));
-        if (std::isfinite(result.position_scale) &&
-            result.position_scale > 0.25 &&
-            result.position_scale < 16.0) {
-          // good
-        } else {
-          throw std::runtime_error("Position scale out of range: " + field);
-        }
-      } else if (field.at(0) == 'f') {
-        result.force_scale = std::stod(field.substr(1));
+    if (!fields[0].empty()) {
+      for (const auto& field : fields) {
+        if (field.at(0) == 'b') {
+          result.bus = std::stol(field.substr(1));
+        } else if (field.at(0) == 'p') {
+          result.position_scale = std::stod(field.substr(1));
+          if (std::isfinite(result.position_scale) &&
+              result.position_scale > 0.25 &&
+              result.position_scale < 16.0) {
+            // good
+          } else {
+            throw std::runtime_error("Position scale out of range: " + field);
+          }
+        } else if (field.at(0) == 'f') {
+          result.force_scale = std::stod(field.substr(1));
 
-        if (std::isfinite(result.force_scale) &&
-            result.force_scale > 0.25 &&
-            result.force_scale < 4.0) {
-          // good
+          if (std::isfinite(result.force_scale) &&
+              result.force_scale > 0.25 &&
+              result.force_scale < 4.0) {
+            // good
+          } else {
+            throw std::runtime_error("Force scale out of range: " + field);
+          }
         } else {
-          throw std::runtime_error("Force scale out of range: " + field);
+          throw std::runtime_error("Unknown option: " + field);
         }
-      } else {
-        throw std::runtime_error("Unknown option: " + field);
       }
     }
     return result;

--- a/nlateral_demo.cc
+++ b/nlateral_demo.cc
@@ -79,8 +79,12 @@ struct Servo {
   static Servo Parse(const std::string& message) {
     auto fields = Split(message);
     Servo result;
-    result.id = std::atol(fields[0].c_str());
-    fields[0].erase(fields[0].begin());
+    size_t id_end = 0;
+    while (id_end < fields[0].size() && std::isdigit(fields[0][id_end])) {
+      id_end++;
+    }
+    result.id = std::stol(fields[0].substr(0, id_end));
+    fields[0].erase(0, id_end);
     for (const auto& field : fields) {
       if (field.at(0) == 'b') {
         result.bus = std::stol(field.substr(1));


### PR DESCRIPTION
When specifying a Servo's BUS with the argument "-s XbY" where X is the ID and Y the BUS, the Parse function would treat the fields variable as a string, but it is in fact an std::vector of strings. As such, its first argument is "XbY" and not X as the original code would suggest ('result.id = std::stol(fields.at(0)' would set result.id to XbY). 